### PR TITLE
Apply `overflow: auto` on dialog

### DIFF
--- a/styles-examples/default.css
+++ b/styles-examples/default.css
@@ -11,6 +11,7 @@
     z-index: 100;
     padding: 10px;
     box-shadow: 0 0 4px rgba(0,0,0,.14),0 4px 8px rgba(0,0,0,.28);
+    overflow: auto;
 }
 
 .skylight-dialog--close {


### PR DESCRIPTION
This way it will crop the dialog content correctly if it's larger than the dialog itself. Previously the content could overlap with the dialog.