### PR TITLE
Adding id as a property for dispatching events

### DIFF
--- a/lib/skylight.js
+++ b/lib/skylight.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
@@ -22,7 +22,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var SkyLight = (function (_React$Component) {
+var SkyLight = function (_React$Component) {
     _inherits(SkyLight, _React$Component);
 
     function SkyLight(props) {
@@ -108,7 +108,7 @@ var SkyLight = (function (_React$Component) {
 
             return _react2.default.createElement(
                 'section',
-                { className: 'skylight-wrapper' },
+                { className: 'skylight-wrapper', id: this.props.id },
                 overlay,
                 _react2.default.createElement(
                     'div',
@@ -132,7 +132,7 @@ var SkyLight = (function (_React$Component) {
     }]);
 
     return SkyLight;
-})(_react2.default.Component);
+}(_react2.default.Component);
 
 SkyLight.displayName = 'SkyLight';
 
@@ -148,7 +148,8 @@ SkyLight.propTypes = {
     overlayStyles: _react2.default.PropTypes.object,
     showOverlay: _react2.default.PropTypes.bool,
     title: _react2.default.PropTypes.string,
-    titleStyle: _react2.default.PropTypes.object
+    titleStyle: _react2.default.PropTypes.object,
+    id: _react2.default.PropTypes.string
 };
 
 SkyLight.defaultProps = {
@@ -157,7 +158,8 @@ SkyLight.defaultProps = {
     overlayStyles: _styles2.default.overlayStyles,
     dialogStyles: _styles2.default.dialogStyles,
     closeButtonStyle: _styles2.default.closeButtonStyle,
-    hideOnOverlayClicked: false
+    hideOnOverlayClicked: false,
+    id: 'skylight'
 };
 
 exports.default = SkyLight;

--- a/src/skylight.js
+++ b/src/skylight.js
@@ -70,7 +70,7 @@ class SkyLight extends React.Component {
     }
 
     return (
-        <section className="skylight-wrapper">
+        <section className="skylight-wrapper" id={this.props.id}>
             {overlay}
             <div style={dialogStyles}>
               <a onClick={() => this.hide()} role="button" style={closeButtonStyle} >&times;</a>
@@ -96,7 +96,8 @@ SkyLight.propTypes = {
   overlayStyles: React.PropTypes.object,
   showOverlay: React.PropTypes.bool,
   title: React.PropTypes.string,
-  titleStyle: React.PropTypes.object
+  titleStyle: React.PropTypes.object,
+  id: React.PropTypes.string,
 };
 
 SkyLight.defaultProps = {
@@ -105,7 +106,8 @@ SkyLight.defaultProps = {
   overlayStyles: styles.overlayStyles,
   dialogStyles: styles.dialogStyles,
   closeButtonStyle: styles.closeButtonStyle,
-  hideOnOverlayClicked: false
+  hideOnOverlayClicked: false,
+  id: 'skylight',
 };
 
 export default SkyLight;


### PR DESCRIPTION
To reference the same Skylight from different triggers in my I app I needed to create a high order component for each unique Skylight that would allow the references to exist in many places without creating the duplication and still keep the core of Skylight untouched.

But using Skylight with the HOC approach meant that I needed also to dispatch events from the HOC to Skylight but there are no unique DOM identifiers by standard so I've made a change to add the ID as a PropType that defaults to `skylight` as standard, allowing anyone using the HOC approach to dispatch the events through to Skylight.