### PR TITLE
use minHeight for responsive layouts 

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -19,7 +19,7 @@ var styles = {
   },
   dialogStyles: {
     width: '50%',
-    height: '400px',
+    minHeight: '400px',
     position: 'fixed',
     top: '50%',
     left: '50%',

--- a/src/styles.js
+++ b/src/styles.js
@@ -14,7 +14,7 @@ const styles = {
   },
   dialogStyles: {
     width: '50%',
-    height: '400px',
+    minHeight: '400px',
     position: 'fixed',
     top: '50%',
     left: '50%',


### PR DESCRIPTION
The default styles use `height` which does not work so well on responsive designs, as the height of the content changes for smaller screens.

Even if I try and set minHeight without a height, the base library still injects a fixed height from it's defaults.

Use `minHeight` instead of `height` in the base styles so responsive designs can also work.