### PR TITLE
Replace deprecated componentWillMount with componenDidMount

### DIFF
--- a/lib/skylightstateless.js
+++ b/lib/skylightstateless.js
@@ -42,8 +42,8 @@ var SkyLightStateless = function (_React$Component) {
   }
 
   _createClass(SkyLightStateless, [{
-    key: 'componentWillMount',
-    value: function componentWillMount() {
+    key: 'componentDidMount',
+    value: function componentDidMount() {
       document.addEventListener("keydown", this._handlerEsc.bind(this));
     }
   }, {

--- a/src/skylightstateless.jsx
+++ b/src/skylightstateless.jsx
@@ -5,7 +5,7 @@ import assign from './utils/assign';
 
 export default class SkyLightStateless extends React.Component {
 
-  componentWillMount() {
+  componentDidMount() {
     document.addEventListener("keydown", this._handlerEsc.bind(this));
   }
 


### PR DESCRIPTION
`componentWillMount` is deprecated in react 16.3 and some linters and frameworks (like Gatsby) fail to build due to the use of the deprecated method `componentWillMount`. The method is only used to add event listeners which is safer to do with `componentDidMount`.