### PR TITLE
Updated deprecated functions to newer versions

### DIFF
--- a/lib/skylight.js
+++ b/lib/skylight.js
@@ -48,8 +48,8 @@ var SkyLight = function (_React$Component) {
   }
 
   _createClass(SkyLight, [{
-    key: 'componentWillUpdate',
-    value: function componentWillUpdate(nextProps, nextState) {
+    key: 'shouldComponentUpdate',
+    value: function shouldComponentUpdate(nextProps, nextState) {
       if (isOpening(this.state, nextState) && this.props.beforeOpen) {
         this.props.beforeOpen();
       }
@@ -57,6 +57,8 @@ var SkyLight = function (_React$Component) {
       if (isClosing(this.state, nextState) && this.props.beforeClose) {
         this.props.beforeClose();
       }
+
+      return true;
     }
   }, {
     key: 'componentDidUpdate',

--- a/lib/skylightstateless.js
+++ b/lib/skylightstateless.js
@@ -42,8 +42,8 @@ var SkyLightStateless = function (_React$Component) {
   }
 
   _createClass(SkyLightStateless, [{
-    key: 'componentWillMount',
-    value: function componentWillMount() {
+    key: 'componentDidMount',
+    value: function componentDidMount() {
       document.addEventListener("keydown", this._handlerEsc.bind(this));
     }
   }, {

--- a/src/skylight.jsx
+++ b/src/skylight.jsx
@@ -12,7 +12,7 @@ export default class SkyLight extends React.Component {
     this.state = { isVisible: false };
   }
 
-  componentWillUpdate(nextProps, nextState) {
+  shouldComponentUpdate(nextProps, nextState) {
     if (isOpening(this.state, nextState) && this.props.beforeOpen) {
       this.props.beforeOpen();
     }
@@ -20,6 +20,8 @@ export default class SkyLight extends React.Component {
     if (isClosing(this.state, nextState) && this.props.beforeClose) {
       this.props.beforeClose();
     }
+
+    return true;
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/src/skylightstateless.jsx
+++ b/src/skylightstateless.jsx
@@ -5,7 +5,7 @@ import assign from './utils/assign';
 
 export default class SkyLightStateless extends React.Component {
 
-  componentWillMount() {
+  componentDidMount() {
     document.addEventListener("keydown", this._handlerEsc.bind(this));
   }
 


### PR DESCRIPTION
React 16.8 deprecated a few of the component lifecycle functions including `componentWillUpdate` and `componentWillMount`. I went ahead and changed the places where these functions were used to use lifecycle functions that are still seen as valid