### PR TITLE
Update webpack config in karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,25 +16,25 @@ module.exports = config => {
     },
     webpack: {
       resolve: {
-        extensions: ['', '.js', '.jsx'],
+        extensions: ['.js', '.jsx'],
       },
       module: {
-        preLoaders: [
+        rules: [
           {
             test: /\.(js|jsx)$/,
             include: path.resolve('src/'),
-            loader: 'isparta',
+            loader: 'isparta-loader',
+            enforce: 'pre',
           },
           {
             test: /\.(js|jsx)?$/,
-            loader: 'eslint',
+            loader: 'eslint-loader',
             exclude: /node_modules/,
+            enforce: 'pre',
           },
-        ],
-        loaders: [
           {
             test: /\.(js|jsx)?$/,
-            loader: 'babel',
+            loader: 'babel-loader',
             exclude: /node_modules/,
           },
         ],


### PR DESCRIPTION
## Summary
- update karma webpack section to use loaders compatible with webpack 2+

## Testing
- `npm test` *(fails: PhantomJS couldn't start)*

------
https://chatgpt.com/codex/tasks/task_e_684de02d4bf483319f73306b5b8802fc